### PR TITLE
Added wait condition for localstack pod to become ready to avoid failre

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@
 
 A set of tools and documentation for learning Crossplane without a network
 connection.
+
+## Requirements
+
+We assume that your system meets the requirements below.
+
+* [docker][docker]
+* [kubectl][kubectl]
+* [helm][helm]
+* [go][go]
+* [kind][kind]
+
+[kind]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation
+[docker]: https://docs.docker.com/engine/install/
+[kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
+[helm]:https://helm.sh/docs/intro/install/#from-script
+[go]: https://golang.org/doc/install

--- a/offline.sh
+++ b/offline.sh
@@ -51,6 +51,8 @@ helm install crossplane -n crossplane-system --create-namespace ./crossplane-1.4
 
 helm install localstack ./localstack-0.3.4.tgz --set startServices="s3" --set image.pullPolicy=Never
 
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=localstack --timeout=30s
+
 kubectl k8scr push crossplane/provider-aws:v0.20.0
 
 kubectl crossplane install provider crossplane/provider-aws:v0.20.0

--- a/online.sh
+++ b/online.sh
@@ -17,5 +17,6 @@ go install github.com/hasheddan/k8scr/cmd/k8scr@latest
 sudo mv ${GOPATH}/bin/k8scr /usr/local/bin/kubectl-k8scr
 
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
+sudo mv kubectl-crossplane /usr/local/bin
 
 echo "\nYou can run offline now!"


### PR DESCRIPTION
If we do not  wait for the localstack pod to become ready the next command `kubectl k8scr push crossplane/provider-aws:v0.20.0` will fail.