### PR TITLE
Use imagePullPolicy: Never for aws-cli-runtime

### DIFF
--- a/docs/WORKSHOP.md
+++ b/docs/WORKSHOP.md
@@ -308,7 +308,7 @@ test-bucket   True    True     8s
 
 Verify that the bucket was created in the localstack backend: 
 ```
-kubectl run aws-cli-runtime --image=luebken/aws-cli-runtime:latest --image-pull-policy='IfNotPresent'
+kubectl run aws-cli-runtime --image=luebken/aws-cli-runtime:latest --image-pull-policy='Never'
 kubectl exec --stdin --tty aws-cli-runtime -- /bin/bash
 
 # configure the aws cli for localstack setup


### PR DESCRIPTION
Updates imagePullPolicy to Never so that the container runtime does not
try to pull the image even when latest tag is used.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>